### PR TITLE
Fix bug parameter checking

### DIFF
--- a/sewpy/sewpy.py
+++ b/sewpy/sewpy.py
@@ -1324,5 +1324,5 @@ class SEW():
 """
 
 	# We turn this text block into a list of the parameter names:
-	fullparamlist = map(lambda s: s[1:-1], re.compile("#\w*\s").findall(fullparamtxt))
+	fullparamlist = list(map(lambda s: s[1:-1], re.compile("#\w*\s").findall(fullparamtxt)))
 


### PR DESCRIPTION
Fix a minor bug where the program always prints an error that the supplied parameters are not found among the defaults (e.g., `Parameter 'MAG_AUTO' seems strange and might be unknown to SExtractor`).